### PR TITLE
Use this when you switch to 1.4

### DIFF
--- a/com/topcat/npclib/DragonAntiPvPListener/NPCManager.java
+++ b/com/topcat/npclib/DragonAntiPvPListener/NPCManager.java
@@ -62,7 +62,7 @@ public class NPCManager {
                         HashSet<String> toRemove = new HashSet<String>();
                         for (String i : NPCManager.this.npcs.keySet()) {
                             Entity j = NPCManager.this.npcs.get(i).getEntity();
-                            j.z();
+                            j.y();
                             if (j.dead) {
                                 toRemove.add(i);
                             }


### PR DESCRIPTION
some functions were renamed in 1.4 in the Entity.java class

this patches npclib to match

i couldnt get it to build but i tested a patch on combattag which did the same thing and it fixes the same error
