### PR TITLE
Fixed Crash in 1.4.7

### DIFF
--- a/com/topcat/npclib/DragonAntiPvPListener/nms/NPCEntity.java
+++ b/com/topcat/npclib/DragonAntiPvPListener/nms/NPCEntity.java
@@ -8,6 +8,7 @@ import net.minecraft.server.v1_4_R1.PlayerInteractManager;
 import net.minecraft.server.v1_4_R1.WorldServer;
 
 import org.bukkit.craftbukkit.v1_4_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_4_R1.entity.CraftEntity;
 import org.bukkit.event.entity.EntityTargetEvent;
 
 import com.topcat.npclib.DragonAntiPvPListener.NPCManager;
@@ -23,7 +24,7 @@ public class NPCEntity extends EntityPlayer {
     private int lastBounceId;
 
     public NPCEntity(NPCManager npcManager, BWorld world, String s,
-        	PlayerInteractManager playerInteractManager) {
+            PlayerInteractManager playerInteractManager) {
         super(npcManager.getServer().getMCServer(), world.getWorldServer(), s,
         		playerInteractManager);
 
@@ -37,7 +38,7 @@ public class NPCEntity extends EntityPlayer {
         this.fauxSleeping = true;
     }
 
-    public void setBukkitEntity(org.bukkit.entity.Entity entity) {
+    public void setBukkitEntity(CraftEntity entity) {
         this.bukkitEntity = entity;
     }
 


### PR DESCRIPTION
Fixes crash

java.lang.NoSuchMethodError: net.minecraft.server.v1_4_R1.EntityHuman.getBukkitEntity()Lorg/bukkit/entity/HumanEntity;
    at com.topcat.npclib.DragonAntiPvPListener.nms.NPCEntity.a(NPCEntity.java:47)
    at net.minecraft.server.v1_4_R1.EntityHuman.p(EntityHuman.java:728)
    at net.minecraft.server.v1_4_R1.PlayerConnection.a(PlayerConnection.java:1103)
    at net.minecraft.server.v1_4_R1.Packet7UseEntity.handle(SourceFile:36)
    at net.minecraft.server.v1_4_R1.NetworkManager.b(NetworkManager.java:290)
    at net.minecraft.server.v1_4_R1.PlayerConnection.d(PlayerConnection.java:113)
    at net.minecraft.server.v1_4_R1.ServerConnection.b(SourceFile:39)
    at net.minecraft.server.v1_4_R1.DedicatedServerConnection.b(SourceFile:30)
    at net.minecraft.server.v1_4_R1.MinecraftServer.r(MinecraftServer.java:598)
    at net.minecraft.server.v1_4_R1.DedicatedServer.r(DedicatedServer.java:224)
    at net.minecraft.server.v1_4_R1.MinecraftServer.q(MinecraftServer.java:494)
    at net.minecraft.server.v1_4_R1.MinecraftServer.run(MinecraftServer.java:427)
    at net.minecraft.server.v1_4_R1.ThreadServerApplication.run(SourceFile:849)
